### PR TITLE
Prune using dates

### DIFF
--- a/core/src/main/java/net/es/oscars/pce/PruningService.java
+++ b/core/src/main/java/net/es/oscars/pce/PruningService.java
@@ -442,7 +442,6 @@ public class PruningService {
                 // Find what VLAN ids are actually available at A and Z
                 Set<Integer> aAvailableVlanIds = getAvailableVlanIds(urnMap, edge.getA().getUrn(), aRanges, resvVlanMap);
                 Set<Integer> zAvailableVlanIds = getAvailableVlanIds(urnMap, edge.getZ().getUrn(), zRanges, resvVlanMap);
-
                 // Find the intersection of those two set of VLAN ranges
                 overlap = addToOverlap(overlap, aAvailableVlanIds);
                 overlap = addToOverlap(overlap, zAvailableVlanIds);
@@ -491,7 +490,7 @@ public class PruningService {
                     .collect(Collectors.toSet());
         }
         else{
-            return new HashSet<>();
+            return reservableVlanIds;
         }
     }
 

--- a/core/src/main/java/net/es/oscars/pce/PruningService.java
+++ b/core/src/main/java/net/es/oscars/pce/PruningService.java
@@ -5,10 +5,8 @@ import net.es.oscars.dto.IntRange;
 import net.es.oscars.dto.rsrc.ReservableBandwidth;
 import net.es.oscars.helpers.IntRangeParsing;
 import net.es.oscars.resv.dao.ReservedBandwidthRepository;
-import net.es.oscars.resv.ent.RequestedVlanFixtureE;
-import net.es.oscars.resv.ent.RequestedVlanJunctionE;
-import net.es.oscars.resv.ent.RequestedVlanPipeE;
-import net.es.oscars.resv.ent.ReservedBandwidthE;
+import net.es.oscars.resv.dao.ReservedVlanRepository;
+import net.es.oscars.resv.ent.*;
 import net.es.oscars.topo.beans.TopoEdge;
 import net.es.oscars.topo.beans.Topology;
 import net.es.oscars.topo.dao.UrnRepository;
@@ -41,6 +39,9 @@ public class PruningService {
     @Autowired
     private ReservedBandwidthRepository resvBwRepo;
 
+    @Autowired
+    private ReservedVlanRepository resvVlanRepo;
+
 
     /**
      * Prune the topology using a specified bidirectional bandwidth, set of VLANs, and a list of URNs to
@@ -51,8 +52,9 @@ public class PruningService {
      * @param urns - The URNs that will be used to match available resources with elements of the topology.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithBwVlans(Topology topo, Integer Bw, String vlans, List<UrnE> urns){
-        return pruneTopology(topo, Bw, Bw, getIntRangesFromString(vlans), urns);
+    public Topology pruneWithBwVlans(Topology topo, Integer Bw, String vlans, List<UrnE> urns,
+                                     List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
+        return pruneTopology(topo, Bw, Bw, getIntRangesFromString(vlans), urns, rsvBwList, rsvVlanList);
     }
 
     /**
@@ -63,8 +65,9 @@ public class PruningService {
      * @param vlans - Requested VLAN ranges. Any VLAN ID within those ranges can be accepted.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithBwVlans(Topology topo, Integer Bw, String vlans){
-        return pruneTopology(topo, Bw, Bw, getIntRangesFromString(vlans), urnRepo.findAll());
+    public Topology pruneWithBwVlans(Topology topo, Integer Bw, String vlans, Date start, Date end){
+        return pruneTopology(topo, Bw, Bw, getIntRangesFromString(vlans), urnRepo.findAll(),
+                getReservedBandwidth(start, end), getReservedVlans(start, end));
     }
 
     /**
@@ -76,8 +79,9 @@ public class PruningService {
      * @param vlans - Requested VLAN ranges. Any VLAN ID within those ranges can be accepted.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithAZBwVlans(Topology topo, Integer azBw, Integer zaBw, String vlans, List<UrnE> urns){
-        return pruneTopology(topo, azBw, zaBw, getIntRangesFromString(vlans), urns);
+    public Topology pruneWithAZBwVlans(Topology topo, Integer azBw, Integer zaBw, String vlans, List<UrnE> urns,
+                                       List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
+        return pruneTopology(topo, azBw, zaBw, getIntRangesFromString(vlans), urns, rsvBwList, rsvVlanList);
     }
 
     /**
@@ -89,8 +93,9 @@ public class PruningService {
      * @param vlans - Requested VLAN ranges. Any VLAN ID within those ranges can be accepted.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithAZBwVlans(Topology topo, Integer azBw, Integer zaBw, String vlans){
-        return pruneTopology(topo, azBw, zaBw, getIntRangesFromString(vlans), urnRepo.findAll());
+    public Topology pruneWithAZBwVlans(Topology topo, Integer azBw, Integer zaBw, String vlans, Date start, Date end){
+        return pruneTopology(topo, azBw, zaBw, getIntRangesFromString(vlans), urnRepo.findAll(),
+                getReservedBandwidth(start, end), getReservedVlans(start, end));
     }
 
     /**
@@ -101,8 +106,9 @@ public class PruningService {
      * @param urns - The URNs that will be used to match available resources with elements of the topology.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithBw(Topology topo, Integer Bw, List<UrnE> urns){
-        return pruneTopology(topo, Bw, Bw, new ArrayList<>(), urns);
+    public Topology pruneWithBw(Topology topo, Integer Bw, List<UrnE> urns,
+                                List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
+        return pruneTopology(topo, Bw, Bw, new ArrayList<>(), urns, rsvBwList, rsvVlanList);
     }
 
     /**
@@ -113,8 +119,9 @@ public class PruningService {
      * @param Bw - The minimum required bidirectional Bandwidth.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithBw(Topology topo, Integer Bw){
-        return pruneTopology(topo, Bw, Bw, new ArrayList<>(), urnRepo.findAll());
+    public Topology pruneWithBw(Topology topo, Integer Bw, Date start, Date end){
+        return pruneTopology(topo, Bw, Bw, new ArrayList<>(), urnRepo.findAll(),
+                getReservedBandwidth(start, end), getReservedVlans(start, end));
     }
 
     /**
@@ -127,8 +134,9 @@ public class PruningService {
      * @param urns - The URNs that will be used to match available resources with elements of the topology.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithAZBw(Topology topo, Integer azBw, Integer zaBw, List<UrnE> urns){
-        return pruneTopology(topo, azBw, zaBw, new ArrayList<>(), urns);
+    public Topology pruneWithAZBw(Topology topo, Integer azBw, Integer zaBw, List<UrnE> urns,
+                                  List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
+        return pruneTopology(topo, azBw, zaBw, new ArrayList<>(), urns, rsvBwList, rsvVlanList);
     }
 
     /**
@@ -140,8 +148,9 @@ public class PruningService {
      * @param zaBw - The minimum required undirectional bandwidth in the other direction.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithAZBw(Topology topo, Integer azBw, Integer zaBw){
-        return pruneTopology(topo, azBw, zaBw, new ArrayList<>(), urnRepo.findAll());
+    public Topology pruneWithAZBw(Topology topo, Integer azBw, Integer zaBw, Date start, Date end){
+        return pruneTopology(topo, azBw, zaBw, new ArrayList<>(), urnRepo.findAll(),
+                getReservedBandwidth(start, end), getReservedVlans(start, end));
     }
 
 
@@ -152,12 +161,9 @@ public class PruningService {
      * @param pipe - The logical pipe, from which the requested bandwidth and VLANs are retrieved.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithPipe(Topology topo, RequestedVlanPipeE pipe){
-        assert(pipe != null);
-        assert(topo != null);
-        assert(urnRepo != null);
-        assert(urnRepo.findAll() != null);
-        return pruneWithPipe(topo, pipe, urnRepo.findAll());
+    public Topology pruneWithPipe(Topology topo, RequestedVlanPipeE pipe, Date start, Date end){
+        return pruneWithPipe(topo, pipe, urnRepo.findAll(),
+                getReservedBandwidth(start, end), getReservedVlans(start, end));
     }
 
     /**
@@ -169,13 +175,14 @@ public class PruningService {
      * @param urns - The URNs that will be used to match available resources with elements of the topology.
      * @return The topology with ineligible edges removed.
      */
-    public Topology pruneWithPipe(Topology topo, RequestedVlanPipeE pipe, List<UrnE> urns){
+    public Topology pruneWithPipe(Topology topo, RequestedVlanPipeE pipe, List<UrnE> urns,
+                                  List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
         Integer azBw = pipe.getAzMbps();
         Integer zaBw = pipe.getZaMbps();
         List<IntRange> vlans = new ArrayList<>();
         vlans.addAll(getVlansFromJunction(pipe.getAJunction()));
         vlans.addAll(getVlansFromJunction(pipe.getZJunction()));
-        return pruneTopology(topo, azBw, zaBw, vlans, urns);
+        return pruneTopology(topo, azBw, zaBw, vlans, urns, rsvBwList, rsvVlanList);
     }
 
     /**
@@ -188,16 +195,16 @@ public class PruningService {
      * @param urns - The URNs that will be matched to elements in the topology.
      * @return The topology with ineligible edges removed.
      */
-    private Topology pruneTopology(Topology topo, Integer azBw, Integer zaBw, List<IntRange> vlans, List<UrnE> urns, Date start, Date end){
+    private Topology pruneTopology(Topology topo, Integer azBw, Integer zaBw, List<IntRange> vlans, List<UrnE> urns,
+                                   List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
         //Build map of URN name to UrnE
         Map<String, UrnE> urnMap = buildUrnMap(urns);
 
-        // Get all Reserved Bandwidth between start and end
-        Optional<List<ReservedBandwidthE>> optResvBw = resvBwRepo.findOverlappingInterval(start.toInstant(), end.toInstant());
-        List<ReservedBandwidthE> resvBw = optResvBw.isPresent() ? optResvBw.get() : new ArrayList<>();
+        // Build map of URN to resvBw
+        Map<UrnE, List<ReservedBandwidthE>> resvBwMap = buildReservedBandwidthMap(rsvBwList);
 
-        // Build map of URN name to resvBw
-        Map<UrnE, ReservedBandwidthE> resvBwMap = buildReservedBandwidthMap(resvBw);
+        // Build map of URN to resvVlan
+        Map<UrnE, List<ReservedVlanE>> resvVlanMap = buildReservedVlanMap(rsvVlanList);
 
         // Copy the original topology's layer and set of vertices.
         Topology pruned = new Topology();
@@ -215,18 +222,9 @@ public class PruningService {
         if(pruned.getLayer() == Layer.MPLS || availableEdges.isEmpty()){
             pruned.setEdges(availableEdges);
         }else {
-            pruned.setEdges(findEdgesWithAvailableVlans(availableEdges, urnMap, vlans));
+            pruned.setEdges(findEdgesWithAvailableVlans(availableEdges, urnMap, vlans, resvVlanMap));
         }
         return pruned;
-    }
-
-    /**
-     * Build a mapping of UrnE objects to ReservedBandwidthE objects.
-     * @param resvBw - A list of reserved bandwidths, each having a matching UrnE field
-     * @return A map of UrnE to ReservedBandwidthE objects
-     */
-    private Map<UrnE, ReservedBandwidthE> buildReservedBandwidthMap(List<ReservedBandwidthE> resvBw) {
-        return resvBw.stream().collect(Collectors.toMap(ReservedBandwidthE::getUrn, resv -> resv));
     }
 
     /***
@@ -239,6 +237,66 @@ public class PruningService {
     }
 
     /**
+     * Get a list of all bandwidth reserved between a start and end date/time.
+     * @param start - The start of the time range
+     * @param end - The end of the time range
+     * @return A list of reserved bandwidth
+     */
+    private List<ReservedBandwidthE> getReservedBandwidth(Date start, Date end){
+        // Get all Reserved Bandwidth between start and end
+        Optional<List<ReservedBandwidthE>> optResvBw = resvBwRepo.findOverlappingInterval(start.toInstant(), end.toInstant());
+        return optResvBw.isPresent() ? optResvBw.get() : new ArrayList<>();
+    }
+
+    /**
+     * Get a list of all VLAN IDs reserved between a start and end date/time.
+     * @param start - The start of the time range
+     * @param end - The end of the time range
+     * @return A list of reserved VLAN IDs
+     */
+    private List<ReservedVlanE> getReservedVlans(Date start, Date end){
+        //Get all Reserved VLan between start and end
+        Optional<List<ReservedVlanE>> optResvVlan = resvVlanRepo.findOverlappingInterval(start.toInstant(), end.toInstant());
+        return optResvVlan.isPresent() ? optResvVlan.get() : new ArrayList<>();
+    }
+
+    /**
+     * Build a mapping of UrnE objects to ReservedBandwidthE objects.
+     * @param rsvBwList A list of all bandwidth reserved.
+     * @return A map of UrnE to ReservedBandwidthE objects
+     */
+    private Map<UrnE, List<ReservedBandwidthE>> buildReservedBandwidthMap(List<ReservedBandwidthE> rsvBwList) {
+        Map<UrnE, List<ReservedBandwidthE>> map = new HashMap<>();
+        for(ReservedBandwidthE resv : rsvBwList){
+            UrnE resvUrn = resv.getUrn();
+            if(!map.containsKey(resvUrn)){
+                map.put(resvUrn, new ArrayList<>());
+            }
+            map.get(resvUrn).add(resv);
+        }
+        return map;
+    }
+
+    /**
+     * Build a mapping of UrnE objects to ReservedVlanE objects.
+     * @param rsvVlanList - A list of all reserved VLAN IDs
+     * @return A map of UrnE to ReservedVlanE objects
+     */
+    private Map<UrnE, List<ReservedVlanE>> buildReservedVlanMap(List<ReservedVlanE> rsvVlanList) {
+
+        Map<UrnE, List<ReservedVlanE>> map = new HashMap<>();
+        for(ReservedVlanE resv : rsvVlanList){
+            UrnE resvUrn = resv.getUrn();
+            if(!map.containsKey(resvUrn)){
+                map.put(resvUrn, new ArrayList<>());
+            }
+            map.get(resvUrn).add(resv);
+        }
+        return map;
+    }
+
+
+    /**
      * Evaluate an edge to determine if the nodes on either end of the edge support the requested
      * az and za bandwidths. An edge will only fail the test if one or both URNs (corresponding to the nodes):
      * (1) have valid reservable bandwidth fields, and (2) the URN(s) do not have sufficient reservable bandwidth
@@ -249,43 +307,56 @@ public class PruningService {
      * @param urnMap - Map of URN name to UrnE object.
      * @return True if there is sufficient reservable bandwidth, False otherwise.
      */
-    private boolean bwAvailable(TopoEdge edge, Integer azBw, Integer zaBw, Map<String, UrnE> urnMap, Map<UrnE, ReservedBandwidthE> resvBwMap){
+    private boolean bwAvailable(TopoEdge edge, Integer azBw, Integer zaBw, Map<String, UrnE> urnMap, Map<UrnE, List<ReservedBandwidthE>> resvBwMap){
         // Get the reservable bandwidth for the URN matching the node on the "a" side of the edge.
         ReservableBandwidthE aBandwidth = urnMap.get(edge.getA().getUrn()).getReservableBandwidth();
         // Get the reservable bandwidth for the URN matching the node on the "z" side of the edge.
         ReservableBandwidthE zBandwidth = urnMap.get(edge.getZ().getUrn()).getReservableBandwidth();
 
-        // Get a map of the available Ingress/Egress bandwidth for URN a
-        Map<String, Integer> aAvailBwMap = getBwAvailabilityForUrn(aBandwidth, resvBwMap);
-        // Get a map of the available Ingress/Egress bandwidth for URN z
 
-        // If both are empty, then neither node has a reservable bandwidth field, so there is no need to remove the edge
-        if (aBandwidth == null && zBandwidth == null) {
-            return true;
-        } else {
-            // At least one of the two has reservable bandwidth, so check the valid nodes to determine
-            // If they have sufficient bandwidth. In the case of a (device, port) edge, only the port must be checked.
-            // If it is a (port, port) edge, then both must be checked.
-            boolean aPasses = true;
-            boolean zPasses = true;
-            if(aBandwidth != null){
-                aPasses = aBandwidth.getEgressBw() >= azBw && aBandwidth.getIngressBw() >= zaBw;
-            }
-            if(zBandwidth != null){
-                zPasses = zBandwidth.getIngressBw() >= azBw && zBandwidth.getEgressBw() >= zaBw;
-            }
-
-            return aPasses && zPasses;
-
+        // At least one of the two has reservable bandwidth, so check the valid nodes to determine
+        // If they have sufficient bandwidth. In the case of a (device, port) edge, only the port must be checked.
+        // If it is a (port, port) edge, then both must be checked.
+        boolean aPasses = true;
+        boolean zPasses = true;
+        if(aBandwidth != null){
+            // Get a map of the available Ingress/Egress bandwidth for URN a
+            Map<String, Integer> aAvailBwMap = getBwAvailabilityForUrn(aBandwidth, resvBwMap);
+            aPasses = aAvailBwMap.get("Egress") >= azBw && aAvailBwMap.get("Ingress") >= zaBw;
         }
+        if(zBandwidth != null){
+            // Get a map of the available Ingress/Egress bandwidth for URN z
+            Map<String, Integer> zAvailBwMap = getBwAvailabilityForUrn(zBandwidth, resvBwMap);
+            zPasses = zAvailBwMap.get("Ingress") >= azBw && zAvailBwMap.get("Egress") >= zaBw;
+        }
+
+        return aPasses && zPasses;
+
+
     }
 
-    private Map<String,Integer> getBwAvailabilityForUrn(ReservableBandwidthE aBandwidth, Map<UrnE, ReservedBandwidthE> resvBwMap) {
+    /**
+     * Determine how much Ingress/Egress bandwidth is still available at a URN. If the list of reserved bandwidths
+     * is empty, then all of the Reservable Bandwidth at that URN is available. Otherwise,
+     * subtract the sum Ingress/Egress bandwidth from the maximum reservable bandwidth at that URN.
+     * @param bandwidth - ReservableBandwidthE object, which contains the maximum Ingress/Egress bandwidth for a given URN
+     * @param resvBwMap - A Mapping from a URN to a list of Reserved Bandwidths at that URN.
+     * @return A map containing the net available ingress/egress bandwidth at a URN
+     */
+    private Map<String,Integer> getBwAvailabilityForUrn(ReservableBandwidthE bandwidth, Map<UrnE, List<ReservedBandwidthE>> resvBwMap) {
         Map<String, Integer> availBw = new HashMap<>();
-        availBw.put("Ingress", 0);
-        availBw.put("Egress", 0);
-        if(resvBwMap.containsKey(aBandwidth.getUrn())){
-            List<>resvBwMap.get(aBandwidth.getUrn())
+        availBw.put("Ingress", bandwidth.getIngressBw());
+        availBw.put("Egress", bandwidth.getEgressBw());
+        if(resvBwMap.containsKey(bandwidth.getUrn())){
+            List<ReservedBandwidthE> resvBwList = resvBwMap.get(bandwidth.getUrn());
+            Integer sumIngress = 0;
+            Integer sumEgress = 0;
+            for(ReservedBandwidthE resv : resvBwList){
+                sumIngress += resv.getInBandwidth();
+                sumEgress += resv.getEgBandwidth();
+            }
+            availBw.put("Ingress", Math.max(bandwidth.getIngressBw() - sumIngress, 0));
+            availBw.put("Egress", Math.max(bandwidth.getEgressBw() - sumEgress, 0));
         }
         return availBw;
     }
@@ -298,11 +369,13 @@ public class PruningService {
      * @param availableEdges - The set of currently available edges, which will be pruned further using VLAN tags.
      * @param urnMap - Map of URN name to UrnE object.
      * @param vlans - Requested VLAN ranges. Any VLAN ID within those ranges can be accepted.
+     * @param resvVlanMap - Map of UrnE objects to a List<> of Reserved VLAN tags.
      * @return The input edges, pruned using the input set of VLAN tags.
      */
-    private Set<TopoEdge> findEdgesWithAvailableVlans(Set<TopoEdge> availableEdges, Map<String, UrnE> urnMap, List<IntRange> vlans) {
+    private Set<TopoEdge> findEdgesWithAvailableVlans(Set<TopoEdge> availableEdges, Map<String, UrnE> urnMap,
+                                                      List<IntRange> vlans, Map<UrnE, List<ReservedVlanE>> resvVlanMap) {
         // Find a set of matching edges for each available VLAN id
-        Map<Integer, Set<TopoEdge>> edgesPerId = findEdgesPerVlanId(availableEdges, urnMap);
+        Map<Integer, Set<TopoEdge>> edgesPerId = findEdgesPerVlanId(availableEdges, urnMap, resvVlanMap);
         // Get a set of the requested VLAN ids
         Set<Integer> idsInRanges = getIntegersFromRanges(vlans);
         // Find the largest set of TopoEdges that meet the request
@@ -339,39 +412,23 @@ public class PruningService {
     }
 
     /**
-     * Using the list of URNs and the URN string, find the matching UrnE object and retrieve all of its
-     * IntRanges.
-     * @param urnMap - Map of URN name to UrnE object.
-     * @param matchingUrn - String representation of the desired URN.
-     * @return - All IntRanges supported at the URN.
-     */
-    private Set<IntRange> getVlanRangesFromUrn(Map<String, UrnE> urnMap, String matchingUrn){
-        if(urnMap.get(matchingUrn) == null || urnMap.get(matchingUrn).getReservableVlans() == null)
-            return new HashSet<>();
-        return urnMap.get(matchingUrn)
-                .getReservableVlans()
-                .getVlanRanges()
-                .stream()
-                .map(IntRangeE::toDtoIntRange)
-                .collect(Collectors.toSet());
-    }
-
-    /**
      * Traverse the set of edges, and create a map of VLAN ID to the edges where that ID is available
      * @param edges - The set of edges.
      * @param urnMap - Map of URN name to UrnE object.
      * @return A (possibly empty) set of VLAN tags that are available across every edge.
      */
-    private Map<Integer, Set<TopoEdge>> findEdgesPerVlanId(Set<TopoEdge> edges, Map<String, UrnE> urnMap){
+    private Map<Integer, Set<TopoEdge>> findEdgesPerVlanId(Set<TopoEdge> edges, Map<String, UrnE> urnMap,
+                                                           Map<UrnE, List<ReservedVlanE>> resvVlanMap){
         // Overlap is used to track all VLAN tags that are available across every edge.
         Map<Integer, Set<TopoEdge>> edgesPerId = new HashMap<>();
         edgesPerId.put(-1, new HashSet<>());
         for(TopoEdge edge : edges){
             // Overlap is used to track all VLAN tags that are available across both endpoints of an edge
             Set<Integer> overlap = new HashSet<>();
-            // Get the VLAN ranges available the a and z ends of the edge
-            Set<IntRange> aRanges = getVlanRangesFromUrn(urnMap, edge.getA().getUrn());
-            Set<IntRange> zRanges = getVlanRangesFromUrn(urnMap, edge.getZ().getUrn());
+            // Get all possible VLAN ranges reservable at the a and z ends of the edge
+            List<IntRange> aRanges = getVlanRangesFromUrn(urnMap, edge.getA().getUrn());
+            List<IntRange> zRanges = getVlanRangesFromUrn(urnMap, edge.getZ().getUrn());
+
 
 
             // If neither edge has reservable VLAN fields, add the edge to the "-1" VLAN tag list.
@@ -382,9 +439,13 @@ public class PruningService {
             // Otherwise, find the intersection between the VLAN ranges (if any), and add the edge to the list
             // matching each overlapping VLAN ID.
             else{
+                // Find what VLAN ids are actually available at A and Z
+                Set<Integer> aAvailableVlanIds = getAvailableVlanIds(urnMap, edge.getA().getUrn(), aRanges, resvVlanMap);
+                Set<Integer> zAvailableVlanIds = getAvailableVlanIds(urnMap, edge.getZ().getUrn(), zRanges, resvVlanMap);
+
                 // Find the intersection of those two set of VLAN ranges
-                overlap = addToOverlap(overlap, aRanges);
-                overlap = addToOverlap(overlap, zRanges);
+                overlap = addToOverlap(overlap, aAvailableVlanIds);
+                overlap = addToOverlap(overlap, zAvailableVlanIds);
 
 
                 // For overlapping IDs, put that edge into the map
@@ -401,28 +462,76 @@ public class PruningService {
     }
 
     /**
+     * Get all VLAN IDs available at a URN based on the possible reservable ranges and the currently reserved IDs.
+     * @param urnMap - Mapping of URN string to UrnE objects
+     * @param urn - The currently considered URN string
+     * @param ranges - List of IntRanges, representing all ranges of VLAN IDs supported at this URN
+     * @param resvVlanMap - A mapping representing the Reserved VLANs at a URN
+     * @return Set of VLAN IDs that are both supported and not reserved at a URN
+     */
+    private Set<Integer> getAvailableVlanIds(Map<String, UrnE> urnMap, String urn, List<IntRange> ranges,
+                                             Map<UrnE, List<ReservedVlanE>> resvVlanMap) {
+        // Get the supported reservable VLAN IDs
+        Set<Integer> reservableVlanIds = getIntegersFromRanges(ranges);
+
+        UrnE aUrn = urnMap.get(urn);
+        // If this URN is in the reserved VLAN map
+        if(resvVlanMap.containsKey(aUrn)) {
+            // Get the reserved VLAN IDs
+            List<Integer> resvVlanIds = resvVlanMap
+                    .get(aUrn)
+                    .stream()
+                    .map(ReservedVlanE::getVlan)
+                    .collect(Collectors.toList());
+
+            // Return the supported IDs that are not reserved
+            return reservableVlanIds
+                    .stream()
+                    .filter(id -> !resvVlanIds.contains(id))
+                    .collect(Collectors.toSet());
+        }
+        else{
+            return new HashSet<>();
+        }
+    }
+
+    /**
+     * Using the list of URNs and the URN string, find the matching UrnE object and retrieve all of its
+     * reservable IntRanges.
+     * @param urnMap - Map of URN name to UrnE object.
+     * @param matchingUrn - String representation of the desired URN.
+     * @return - All IntRanges supported at the URN.
+     */
+    private List<IntRange> getVlanRangesFromUrn(Map<String, UrnE> urnMap, String matchingUrn){
+        if(urnMap.get(matchingUrn) == null || urnMap.get(matchingUrn).getReservableVlans() == null)
+            return new ArrayList<>();
+        return urnMap.get(matchingUrn)
+                .getReservableVlans()
+                .getVlanRanges()
+                .stream()
+                .map(IntRangeE::toDtoIntRange)
+                .collect(Collectors.toList());
+    }
+
+
+    /**
      * Iterate through the set of overlapping VLAN tags, keep the elements in that set which are also
      * contained in every IntRange passed in.
      * @param overlap - The set of overlapping VLAN tags.
-     * @param ranges - The set of IntRanges, corresponding to the VLANs available on a node.
+     * @param other - Another set of VLAN tags, to be overlapped with the current overlapping set.
      * @return The (possibly reduced) set of overlapping VLAN tags.
      */
-    private Set<Integer> addToOverlap(Set<Integer> overlap, Set<IntRange> ranges){
+    private Set<Integer> addToOverlap(Set<Integer> overlap, Set<Integer> other){
         // If there are no ranges available, just return the current overlap set
-        if(ranges.isEmpty()){
+        if(other.isEmpty()){
             return overlap;
         }
-        // Iterate through all passed in IntRanges
-        for(IntRange range : ranges){
-            // Get the set of VLAN tags within that range
-            Set<Integer> numbersInRange = getSetOfNumbersInRange(range);
-            // If the overlap does not already have elements, add all of the tags retrieved from this range
-            if(overlap.isEmpty()){
-                overlap.addAll(numbersInRange);
-            }else{
-                // Otherwise, find the intersection between the current overlap and the tags retrieved from this range
-                overlap.retainAll(numbersInRange);
-            }
+        // If the overlap does not already have elements, add all of the tags retrieved from this range
+        if(overlap.isEmpty()){
+            overlap.addAll(other);
+        }else{
+            // Otherwise, find the intersection between the current overlap and the tags retrieved from this range
+            overlap.retainAll(other);
         }
         return overlap;
     }

--- a/core/src/main/java/net/es/oscars/pce/TopPCE.java
+++ b/core/src/main/java/net/es/oscars/pce/TopPCE.java
@@ -50,9 +50,6 @@ public class TopPCE {
         for (RequestedVlanFlowE req_f : requested.getVlanFlows()) {
             for(RequestedVlanPipeE pipe : req_f.getPipes()){
                 //Prune MPLS and Ethernet Topologies (Bandwidth, VLANs)
-                Topology prunedEthernet = pruningService.pruneWithPipe(topoService.layer(Layer.ETHERNET), pipe);
-                Topology prunedMPLS = pruningService.pruneWithPipe(topoService.layer(Layer.MPLS), pipe);
-
                 //Build specialized service layer topology for this pipe
                 //Run Symmetric Dijkstra on this Topology
                 //Translate the Shortest Path into EROs, then EROs to Junction/Pipes/Fixtures

--- a/core/src/main/java/net/es/oscars/topo/ent/ReservableBandwidthE.java
+++ b/core/src/main/java/net/es/oscars/topo/ent/ReservableBandwidthE.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 @Builder
 @Entity
-
+@EqualsAndHashCode(exclude="urn")
 public class ReservableBandwidthE {
     @Id
     @GeneratedValue

--- a/core/src/main/java/net/es/oscars/topo/ent/ReservableVlanE.java
+++ b/core/src/main/java/net/es/oscars/topo/ent/ReservableVlanE.java
@@ -14,6 +14,7 @@ import java.util.Set;
 @AllArgsConstructor
 @Builder
 @Entity
+@EqualsAndHashCode(exclude="urn")
 public class ReservableVlanE {
     @Id
     @GeneratedValue

--- a/core/src/test/java/net/es/oscars/pce/PruningServiceTest.java
+++ b/core/src/test/java/net/es/oscars/pce/PruningServiceTest.java
@@ -196,14 +196,33 @@ public class PruningServiceTest {
         List<UrnE> urns = buildUrnList();
         List<ReservedBandwidthE> rsvBwList = buildReservedBandwidthList(urns, 10);
         List<ReservedVlanE> rsvVlanList = buildReservedVlanList(urns, Arrays.asList(1,2,3));
+
         log.info("VLAN expression: 9-10");
         Topology pruned = pruningService.pruneWithBwVlans(topo, 20, "9-10", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() == topo.getEdges().size());
+
         log.info("VLAN expression: 20:3");
         pruned = pruningService.pruneWithBwVlans(topo, 20, "20:3", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() == topo.getEdges().size());
+
         log.info("VLAN expression: jiofashjfiasf");
         pruned = pruningService.pruneWithBwVlans(topo, 20, "jiofashjfiasf", urns, rsvBwList, rsvVlanList);
+        assert(pruned.getEdges().size() == topo.getEdges().size());
+
+        log.info("Pruning using empty Reserved Bandwidth List");
+        pruned = pruningService.pruneWithBwVlans(topo, 20, "1:10", urns, new ArrayList<ReservedBandwidthE>(), rsvVlanList);
+        assert(pruned.getEdges().size() == topo.getEdges().size());
+
+        log.info("Pruning using empty Reserved VLAN List");
+        pruned = pruningService.pruneWithBwVlans(topo, 20, "1", urns, rsvBwList, new ArrayList<ReservedVlanE>());
+        assert(pruned.getEdges().size() == topo.getEdges().size());
+
+        log.info("Pruning using empty Reserved VLAN and Bandwidth List");
+        pruned = pruningService.pruneWithBwVlans(topo, 20, "1", urns, new ArrayList<ReservedBandwidthE>(), new ArrayList<ReservedVlanE>());
+        assert(pruned.getEdges().size() == topo.getEdges().size());
+
+        log.info("Pruning using empty Reserved VLAN and Bandwidth List and incorrect expression");
+        pruned = pruningService.pruneWithBwVlans(topo, 20, "~~~", urns, new ArrayList<ReservedBandwidthE>(), new ArrayList<ReservedVlanE>());
         assert(pruned.getEdges().size() == topo.getEdges().size());
     }
 
@@ -398,7 +417,7 @@ public class PruningServiceTest {
         List<ReservedBandwidthE> reservedBandwidth = new ArrayList<>();
 
         for(UrnE urn : urns){
-            if(urn.getIfceType() != null){
+            if(urn.getUrnType() == UrnType.IFCE){
                 ReservedBandwidthE rsvBw = ReservedBandwidthE.builder()
                         .urn(urn)
                         .bandwidth(bandwidth)
@@ -418,7 +437,7 @@ public class PruningServiceTest {
 
         for(UrnE urn : urns){
             for(Integer vlanId : vlanIds){
-                if(urn.getIfceType() != null){
+                if(urn.getUrnType() == UrnType.IFCE){
                     ReservedVlanE rsvVlan = ReservedVlanE.builder()
                             .urn(urn)
                             .vlan(vlanId)

--- a/core/src/test/java/net/es/oscars/pce/PruningServiceTest.java
+++ b/core/src/test/java/net/es/oscars/pce/PruningServiceTest.java
@@ -2,6 +2,8 @@ package net.es.oscars.pce;
 
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.CoreUnitTestConfiguration;
+import net.es.oscars.resv.ent.ReservedBandwidthE;
+import net.es.oscars.resv.ent.ReservedVlanE;
 import net.es.oscars.topo.beans.Topology;
 import net.es.oscars.topo.dao.UrnRepository;
 import net.es.oscars.topo.ent.IntRangeE;
@@ -18,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.time.Instant;
 import java.util.*;
 
 @Slf4j
@@ -41,17 +44,23 @@ public class PruningServiceTest {
         List<UrnE> urns = buildUrnList();
         log.info("Built list of URNs");
         log.info(urns.toString());
+        List<ReservedBandwidthE> rsvBwList = buildReservedBandwidthList(urns, 10);
+        log.info("Built list of Reserved Bandwidth");
+        log.info(rsvBwList.toString());
+        List<ReservedVlanE> rsvVlanList = buildReservedVlanList(urns, Arrays.asList(1,2,3));
+        log.info("Built list of Reserved VLANs");
+        log.info(rsvVlanList.toString());
 
         log.info("Pruning - Remove no edges");
-        Topology pruned = pruningService.pruneWithBw(topo, 100, urns);
+        Topology pruned = pruningService.pruneWithBw(topo, 100, urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() == topo.getEdges().size());
 
         log.info("Pruning - Remove every edge");
-        pruned = pruningService.pruneWithBw(topo, 175, urns);
+        pruned = pruningService.pruneWithBw(topo, 175, urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().isEmpty());
 
         log.info("Pruning - Remove only some edges");
-        pruned = pruningService.pruneWithBw(topo, 150, urns);
+        pruned = pruningService.pruneWithBw(topo, 140, urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() < topo.getEdges().size());
         assert(!pruned.getEdges().isEmpty());
         assert(!getEdgeByEndpoints(pruned, "swA", "swA:1").isPresent());
@@ -64,6 +73,7 @@ public class PruningServiceTest {
         assert(!getEdgeByEndpoints(pruned, "swC", "swC:2").isPresent());
     }
 
+
     @Test
     public void testAZBwPrune(){
         log.info("Pruning using AZ & ZA Bandwidth");
@@ -73,17 +83,23 @@ public class PruningServiceTest {
         List<UrnE> urns = buildUrnList();
         log.info("Built list of URNs");
         log.info(urns.toString());
+        List<ReservedBandwidthE> rsvBwList = buildReservedBandwidthList(urns, 10);
+        log.info("Built list of Reserved Bandwidth");
+        log.info(rsvBwList.toString());
+        List<ReservedVlanE> rsvVlanList = buildReservedVlanList(urns, Arrays.asList(1,2,3));
+        log.info("Built list of Reserved VLANs");
+        log.info(rsvVlanList.toString());
 
         log.info("Pruning - Remove no edges");
-        Topology pruned = pruningService.pruneWithAZBw(topo, 100, 125, urns);
+        Topology pruned = pruningService.pruneWithAZBw(topo, 100, 115, urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() == topo.getEdges().size());
 
         log.info("Pruning - Remove every edge");
-        pruned = pruningService.pruneWithAZBw(topo, 175, 100, urns);
+        pruned = pruningService.pruneWithAZBw(topo, 175, 100, urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().isEmpty());
 
         log.info("Pruning - Remove only some edges");
-        pruned = pruningService.pruneWithAZBw(topo, 150, 125, urns);
+        pruned = pruningService.pruneWithAZBw(topo, 140, 115, urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() < topo.getEdges().size());
         assert(!pruned.getEdges().isEmpty());
         assert(getEdgeByEndpoints(pruned, "swA", "swA:1").isPresent());
@@ -105,17 +121,23 @@ public class PruningServiceTest {
         List<UrnE> urns = buildUrnList();
         log.info("Built list of URNs");
         log.info(urns.toString());
+        List<ReservedBandwidthE> rsvBwList = buildReservedBandwidthList(urns, 10);
+        log.info("Built list of Reserved Bandwidth");
+        log.info(rsvBwList.toString());
+        List<ReservedVlanE> rsvVlanList = buildReservedVlanList(urns, Arrays.asList(1,2,3));
+        log.info("Built list of Reserved VLANs");
+        log.info(rsvVlanList.toString());
 
         log.info("Pruning - Remove no edges");
-        Topology pruned = pruningService.pruneWithBwVlans(topo, 100, "2:5", urns);
+        Topology pruned = pruningService.pruneWithBwVlans(topo, 100, "2:5", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() == topo.getEdges().size());
 
         log.info("Pruning - Remove every edge");
-        pruned = pruningService.pruneWithBwVlans(topo, 150, "90:120", urns);
+        pruned = pruningService.pruneWithBwVlans(topo, 150, "90:120", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().isEmpty());
 
         log.info("Pruning - Remove only some edges");
-        pruned = pruningService.pruneWithBwVlans(topo, 125, "11:20,21:27,29", urns);
+        pruned = pruningService.pruneWithBwVlans(topo, 115, "11:20,21:27,29", urns, rsvBwList, rsvVlanList);
         log.info(pruned.getEdges().toString());
         assert(pruned.getEdges().size() < topo.getEdges().size());
         assert(!pruned.getEdges().isEmpty());
@@ -138,17 +160,23 @@ public class PruningServiceTest {
         List<UrnE> urns = buildUrnList();
         log.info("Built list of URNs");
         log.info(urns.toString());
+        List<ReservedBandwidthE> rsvBwList = buildReservedBandwidthList(urns, 10);
+        log.info("Built list of Reserved Bandwidth");
+        log.info(rsvBwList.toString());
+        List<ReservedVlanE> rsvVlanList = buildReservedVlanList(urns, Arrays.asList(1,2,3));
+        log.info("Built list of Reserved VLANs");
+        log.info(rsvVlanList.toString());
 
         log.info("Pruning - Remove no edges");
-        Topology pruned = pruningService.pruneWithAZBwVlans(topo, 100, 125, "3,4,10", urns);
+        Topology pruned = pruningService.pruneWithAZBwVlans(topo, 100, 115, "3,4,10", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() == topo.getEdges().size());
 
         log.info("Pruning - Remove every edge");
-        pruned = pruningService.pruneWithAZBwVlans(topo, 175, 100, "80:90", urns);
+        pruned = pruningService.pruneWithAZBwVlans(topo, 175, 100, "80:90", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().isEmpty());
 
         log.info("Pruning - Remove only some edges");
-        pruned = pruningService.pruneWithAZBwVlans(topo, 100, 125, "40:45,50", urns);
+        pruned = pruningService.pruneWithAZBwVlans(topo, 100, 115, "40:45,50", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() < topo.getEdges().size());
         assert(!pruned.getEdges().isEmpty());
         assert(!getEdgeByEndpoints(pruned, "swA", "swA:1").isPresent());
@@ -166,57 +194,17 @@ public class PruningServiceTest {
         log.info("Pruning using poorly formatted VLAN expressions");
         Topology topo = buildTopology();
         List<UrnE> urns = buildUrnList();
+        List<ReservedBandwidthE> rsvBwList = buildReservedBandwidthList(urns, 10);
+        List<ReservedVlanE> rsvVlanList = buildReservedVlanList(urns, Arrays.asList(1,2,3));
         log.info("VLAN expression: 9-10");
-        Topology pruned = pruningService.pruneWithBwVlans(topo, 20, "9-10", urns);
+        Topology pruned = pruningService.pruneWithBwVlans(topo, 20, "9-10", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() == topo.getEdges().size());
         log.info("VLAN expression: 20:3");
-        pruned = pruningService.pruneWithBwVlans(topo, 20, "20:3", urns);
+        pruned = pruningService.pruneWithBwVlans(topo, 20, "20:3", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() == topo.getEdges().size());
         log.info("VLAN expression: jiofashjfiasf");
-        pruned = pruningService.pruneWithBwVlans(topo, 20, "jiofashjfiasf", urns);
+        pruned = pruningService.pruneWithBwVlans(topo, 20, "jiofashjfiasf", urns, rsvBwList, rsvVlanList);
         assert(pruned.getEdges().size() == topo.getEdges().size());
-    }
-
-    //@Test
-    public void testBwPruneEthernet(){
-        log.info("Pruning using only Bandwidth");
-        Topology topo = topoService.layer(Layer.ETHERNET);
-        log.info("Retrieved Topology");
-        log.info(topo.toString());
-
-        log.info("Pruning - Remove no edges");
-        Topology pruned = pruningService.pruneWithBw(topo, 100);
-        assert(pruned.getEdges().size() == topo.getEdges().size());
-
-        log.info("Pruning - Remove every edge");
-        pruned = pruningService.pruneWithBw(topo, 175);
-        assert(pruned.getEdges().isEmpty());
-
-        log.info("Pruning - Remove only some edges");
-        pruned = pruningService.pruneWithBw(topo, 150);
-        assert(pruned.getEdges().size() < topo.getEdges().size());
-        assert(!pruned.getEdges().isEmpty());
-    }
-
-    //@Test
-    public void testBwPruneMPLS(){
-        log.info("Pruning using only Bandwidth");
-        Topology topo = topoService.layer(Layer.MPLS);
-        log.info("Retrieved Topology");
-        log.info(topo.toString());
-
-        log.info("Pruning - Remove no edges");
-        Topology pruned = pruningService.pruneWithBw(topo, 100);
-        assert(pruned.getEdges().size() == topo.getEdges().size());
-
-        log.info("Pruning - Remove every edge");
-        pruned = pruningService.pruneWithBw(topo, 175);
-        assert(pruned.getEdges().isEmpty());
-
-        log.info("Pruning - Remove only some edges");
-        pruned = pruningService.pruneWithBw(topo, 150);
-        assert(pruned.getEdges().size() < topo.getEdges().size());
-        assert(!pruned.getEdges().isEmpty());
     }
 
 
@@ -404,5 +392,43 @@ public class PruningServiceTest {
                 .egressBw(egress)
                 .urn(urn)
                 .build();
+    }
+
+    private List<ReservedBandwidthE> buildReservedBandwidthList(List<UrnE> urns, Integer bandwidth) {
+        List<ReservedBandwidthE> reservedBandwidth = new ArrayList<>();
+
+        for(UrnE urn : urns){
+            if(urn.getIfceType() != null){
+                ReservedBandwidthE rsvBw = ReservedBandwidthE.builder()
+                        .urn(urn)
+                        .bandwidth(bandwidth)
+                        .inBandwidth(bandwidth)
+                        .egBandwidth(bandwidth)
+                        .beginning(Instant.MIN)
+                        .ending(Instant.MAX)
+                        .build();
+                reservedBandwidth.add(rsvBw);
+            }
+        }
+        return reservedBandwidth;
+    }
+
+    private List<ReservedVlanE> buildReservedVlanList(List<UrnE> urns, List<Integer> vlanIds) {
+        List<ReservedVlanE> reservedVlans = new ArrayList<>();
+
+        for(UrnE urn : urns){
+            for(Integer vlanId : vlanIds){
+                if(urn.getIfceType() != null){
+                    ReservedVlanE rsvVlan = ReservedVlanE.builder()
+                            .urn(urn)
+                            .vlan(vlanId)
+                            .beginning(Instant.MIN)
+                            .ending(Instant.MAX)
+                            .build();
+                    reservedVlans.add(rsvVlan);
+                }
+            }
+        }
+        return reservedVlans;
     }
 }


### PR DESCRIPTION
Remove edges from the topology where the available bandwidth and VLAN IDs between input start and end dates does not support the request. The available bandwidth and VLAN IDs are found by comparing the possible Reservable Bandwidth/VLAN IDs and the Reserved Bandwidth/VLAN IDs during the specified time period. 
